### PR TITLE
Remove scaffolt

### DIFF
--- a/template.js
+++ b/template.js
@@ -60,7 +60,6 @@ exports.template = function(grunt, init, done) {
       'sinon': '*',
       'chai': '*',
       'sinon-chai': '*',
-      'scaffolt': '*'
     };
     // TODO: compute dynamically?
     props.travis = /y/i.test(props.travis);


### PR DESCRIPTION
Hi. This is rather question. Do we need scaffolt as a default template (`grunt-init-node-coffee-mocha`). 
If so where and how do you use?
(I'm not used to using `grunt-init-hogehoge`)
